### PR TITLE
Update ubuntu version in the publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.11]


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to ensure the build job always uses the latest Ubuntu version.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L13-R13): Changed the `runs-on` parameter from `ubuntu-20.04` to `ubuntu-latest` to automatically use the most up-to-date Ubuntu version for the build environment.