### PR TITLE
Fix boot endpoint usage

### DIFF
--- a/transaction_manager/config.py
+++ b/transaction_manager/config.py
@@ -28,8 +28,7 @@ SGX_URL: Optional[str] = 'https://127.0.0.1:1026'
 ETH_PRIVATE_KEY: Optional[str] = None
 
 ENDPOINT: str = 'http://127.0.0.1:8545'
-BOOT_ENDPOINT: str = 'http://127.0.0.1:8545'
-SKALE_NETWORK_TYPE: str = 'skale'
+BOOT_ENDPOINT: str = ''
 
 LOCAL_SKALED_ENDPOINT_REDIS_KEY = 'node_config_mirage_local_endpoint'
 

--- a/transaction_manager/resources.py
+++ b/transaction_manager/resources.py
@@ -30,7 +30,6 @@ from .config import (
     REDIS_URI,
     STATSD_HOST,
     STATSD_PORT,
-    SKALE_NETWORK_TYPE,
     BOOT_ENDPOINT,
     LOCAL_SKALED_ENDPOINT_REDIS_KEY,
 )
@@ -48,7 +47,7 @@ def w3() -> Web3:
 
 
 def endpoints() -> list[str]:
-    if SKALE_NETWORK_TYPE == 'skale':
+    if BOOT_ENDPOINT == '':
         return [ENDPOINT]
 
     endpoints = [BOOT_ENDPOINT]


### PR DESCRIPTION
This pull request updates the configuration and logic in the `transaction_manager` module by removing the `SKALE_NETWORK_TYPE` variable and modifying the behavior of the `BOOT_ENDPOINT` variable. These changes simplify the codebase and adjust the logic for determining endpoints.

### Configuration changes:
* [`transaction_manager/config.py`](diffhunk://#diff-80d2b90007e63c35b29f6f34c3b0d09b9647d597d876965c63aeb66990bccf17L31-R31): Removed the `SKALE_NETWORK_TYPE` variable and set the default value of `BOOT_ENDPOINT` to an empty string instead of duplicating the `ENDPOINT` value.

### Code logic adjustments:
* [`transaction_manager/resources.py`](diffhunk://#diff-b31f5b1460394618e4f05d0ede108f08db149c190787d2ccef2d3ff18a285166L33): Removed `SKALE_NETWORK_TYPE` from the list of imported variables.
* [`transaction_manager/resources.py`](diffhunk://#diff-b31f5b1460394618e4f05d0ede108f08db149c190787d2ccef2d3ff18a285166L51-R50): Updated the `endpoints` function to check if `BOOT_ENDPOINT` is an empty string instead of relying on `SKALE_NETWORK_TYPE` to determine the list of endpoints.