### PR TITLE
Add comments to improve readability

### DIFF
--- a/transaction_manager/attempt_manager/v2.py
+++ b/transaction_manager/attempt_manager/v2.py
@@ -168,8 +168,10 @@ class AttemptManagerV2(BaseAttemptManager):
         logger.info('Estimated gas %d', estimated_gas)
         tx.gas = max(estimated_gas, tx.gas or 0)
         if tx.gas > estimated_gas:
-            allowed_fee = self.max_allowed_fee(tx.gas, tx.value)
-            if allowed_fee < next_fee.max_fee_per_gas:  # type: ignore
+            # maximum fee that we can allow for tx.gas, tx.value and tx.source balance
+            max_allowed_fee_for_suggested_gas = self.max_allowed_fee(tx.gas, tx.value)
+            # if account balance is not enough to cover suggested gas with chosen gas price
+            if next_fee.max_fee_per_gas > max_allowed_fee_for_suggested_gas:  # type: ignore
                 logger.warning('Suggested fee exceeds allowance. Defaulting to %d', estimated_gas)
                 tx.gas = estimated_gas
             else:


### PR DESCRIPTION
This pull request makes a targeted improvement to the gas fee validation logic in the `make` method of `AttemptManagerV2`. The main change is a clarification and renaming of variables to make it more explicit that the maximum allowed fee is being calculated for the suggested gas and transaction value, and to clarify the logic for handling cases where the suggested fee exceeds the allowed maximum.

Gas fee validation logic improvement:

* In `transaction_manager/attempt_manager/v2.py`, the variable for the maximum allowed fee is renamed to `max_allowed_fee_for_suggested_gas` and the comment is updated to clarify that the check ensures the account balance can cover the suggested gas with the chosen gas price. The conditional logic is also clarified for better readability.